### PR TITLE
migrate to localstack auth login

### DIFF
--- a/04-cloud-pods-persistence/README.md
+++ b/04-cloud-pods-persistence/README.md
@@ -12,7 +12,7 @@ $ pip install --upgrade --pre localstack localstack-ext
 
 Using cloud pods requires creating an account on https://app.localstack.cloud, and then using the account credentials to log in to the CLI:
 ```
-$ localstack login
+$ localstack auth login
 ...
 ```
 


### PR DESCRIPTION
## Motivation
`localstack login` has been deprecated in favor of `localstack auth login` for quite a while (at least `3.0`).

## Changes
This PR changes the usages of `localstack login` in this repo to `localstack auth login`.