### PR TITLE
migrate from API key to auth token everywhere

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Start up LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           docker pull localstack/localstack-pro &
 
@@ -28,7 +28,7 @@ jobs:
 
       - name: Run simple test
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           set -e
 

--- a/01-serverless-image-resizer/README.md
+++ b/01-serverless-image-resizer/README.md
@@ -70,7 +70,7 @@ pip install -r requirements-dev.txt
 Start LocalStack Pro with the appropriate CORS configuration for the S3 Website:
 
 ```bash
-LOCALSTACK_API_KEY=... localstack start
+LOCALSTACK_AUTH_TOKEN=... localstack start
 ```
 
 ## Instructions

--- a/02-serverless-api-ecs-apigateway/README.md
+++ b/02-serverless-api-ecs-apigateway/README.md
@@ -39,7 +39,7 @@ We are using the following AWS services and their features to build our infrastr
 Start LocalStack Pro with the appropriate configuration to enable the S3 website to send requests to the container APIs:
 
 ```shell
-export LOCALSTACK_API_KEY=<your-api-key>
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
 EXTRA_CORS_ALLOWED_ORIGINS=http://sample-app.s3.localhost.localstack.cloud:4566 DISABLE_CUSTOM_CORS_APIGATEWAY=1 DEBUG=1 localstack start
 ```
 
@@ -197,7 +197,7 @@ localstack pod save file://<path_to_disk>/<pod-name>
 
 The above command will create a zip file named `<pod-name>` to the specified location on the disk.
 
-The `load` command is the inverse operation of the `save` command. It retrieves the content of a previously stored Cloud Pod from the local file system or the LocalStack Web Application and injects it into the application runtime. On an alternate machine, start LocalStack with the API key configured, and pull the Cloud Pod we created previously using the `load` command with the Cloud Pod name as the first argument:
+The `load` command is the inverse operation of the `save` command. It retrieves the content of a previously stored Cloud Pod from the local file system or the LocalStack Web Application and injects it into the application runtime. On an alternate machine, start LocalStack with the auth token configured, and pull the Cloud Pod we created previously using the `load` command with the Cloud Pod name as the first argument:
 
 ```bash
 localstack pod load <pod-name>
@@ -255,12 +255,12 @@ This application sample hosts an example GitHub Action workflow that starts up L
 
 The most relevant steps in the CI pipeline are:
 
-- Starting LocalStack, after setting the API Key as a secret in GitHub.
+- Starting LocalStack, after setting the auth token as a secret in GitHub.
 
 ```yaml
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           DNS_ADDRESS: 0
         run: |
           pip install localstack awscli-local[ver1]

--- a/03-appsync-graphql-api-cdk/README.md
+++ b/03-appsync-graphql-api-cdk/README.md
@@ -33,10 +33,10 @@ We are using the following AWS services and third-party integrations to build ou
 - [`cURL`](https://curl.se/)
 - [`wscat`](https://github.com/websockets/wscat)
 
-Start LocalStack Pro with the `LOCALSTACK_API_KEY` pre-configured:
+Start LocalStack Pro with the `LOCALSTACK_AUTH_TOKEN` pre-configured:
 
 ```sh
-export LOCALSTACK_API_KEY=<your-api-key>
+export LOCALSTACK_AUTH_TOKEN=<your-auth-token>
 localstack start
 ```
 

--- a/04-cloud-pods-persistence/README.md
+++ b/04-cloud-pods-persistence/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-* LocalStack Team plan (configured with API key)
+* LocalStack Team plan (configured with auth token)
 * `localstack` CLI
 
 To install the latest dev release of the CLI, we can use this command:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Note: The project can either be cloned and installed on your local machine, or y
 
 * Docker
 * Python/`pip`
-* LocalStack Pro API key ([free trial key here](https://app.localstack.cloud))
+* LocalStack Pro auth token ([free trial key here](https://app.localstack.cloud))
 
 ## Installation & Getting Started
 
@@ -27,7 +27,7 @@ pip install localstack
 ```
 Then we can simply start the LocalStack container locally:
 ```
-export LOCALSTACK_API_KEY=... # insert your API key here
+export LOCALSTACK_AUTH_TOKEN=... # insert your auth token here
 DEBUG=1 localstack start
 ```
 


### PR DESCRIPTION
## Motivation
With [LocalStack 4.0.0](https://github.com/localstack/localstack/releases/tag/v4.0.0), API keys have been fully migrated to auth tokens by also providing CI auth tokens.
This PR switches to using a new CI auth token instead of the old CI API key in the pipeline.

## Changes
- Use auth token instead of API keys.

/cc @SimonWallner @ackdav 