### PR TITLE
Fix setup.sh overwriting ~/.aws/credentials and ~/.aws/config

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Install tools
         run: |
-          pip install --pre localstack awscli-local[ver1] terraform-local pytest requests
+          pip install --pre localstack awscli-local terraform-local pytest requests
 
           # Terraform
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg

--- a/00-setup/setup.sh
+++ b/00-setup/setup.sh
@@ -17,22 +17,6 @@ else
 fi
 
 echo ""
-echo "Configuring AWS CLI default profile for LocalStack..."
-mkdir -p "${HOME}/.aws"
-cat > "${HOME}/.aws/credentials" << 'EOF'
-[default]
-aws_access_key_id = test
-aws_secret_access_key = test
-EOF
-cat > "${HOME}/.aws/config" << 'EOF'
-[default]
-region = us-east-1
-endpoint_url = http://localhost:4566
-output = json
-EOF
-echo "AWS CLI profile configured."
-
-echo ""
 echo "Starting LocalStack..."
 localstack start -d
 
@@ -42,7 +26,7 @@ localstack wait -t 60
 
 echo ""
 echo "Verifying..."
-aws s3 ls > /dev/null && echo "OK: aws CLI connected (via default profile)"
+awslocal s3 ls > /dev/null && echo "OK: awslocal connected"
 curl -sf http://localhost:4566/_localstack/health | python3 -m json.tool | grep -q '"running"' && echo "OK: health check passed"
 
 echo ""


### PR DESCRIPTION
## Summary
- `00-setup/setup.sh` used `cat > ~/.aws/credentials` and `cat > ~/.aws/config` to inject dummy LocalStack credentials into the default profile, truncating both files and destroying any existing real AWS profiles a user had configured. This was reported by a workshop attendee.
- The verification step now uses `awslocal` (already listed as a required tool in `00-setup/README.md`) instead of raw `aws`. `awslocal` sets dummy credentials and the local endpoint via environment variables scoped to that single invocation, so it never touches `~/.aws/*`. This also brings `setup.sh` in line with every other module in the workshop, which already uses `awslocal`/`tflocal`/etc.

---

Big thank you to @kakakakakku for reporting this issue on [Twitter](https://x.com/kakakakakku/status/2089696056615555285) 🙏 , and apologies for the inconvenience this may have caused!

## Test plan
- [ ] Run `./00-setup/setup.sh` with an existing `~/.aws/credentials`/`~/.aws/config` containing real profiles and confirm they are left untouched.
- [ ] Confirm the script still starts LocalStack, waits for readiness, and passes the `awslocal s3 ls` / health check verification steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)