### PR TITLE
Add --recursive to the S3 receipts check in module 01

### DIFF
--- a/01-serverless-app/README.md
+++ b/01-serverless-app/README.md
@@ -86,7 +86,7 @@ curl -s "$API/orders" | python3 -m json.tool
 awslocal dynamodb scan --table-name orders
 
 # Check S3 receipts
-awslocal s3 ls s3://order-receipts/
+awslocal s3 ls --recursive s3://order-receipts/
 ```
 
 ### Open the UI


### PR DESCRIPTION
Thank you for this great workshop!
I noticed a small improvement while working through it (it might be a tiny one 😀), so I'm sending it your way.

## Changes
In module 01, running the `awslocal s3 ls` command only shows the folder.

```sh
$ awslocal s3 ls s3://order-receipts/
                           PRE receipts/
```

Since we want to check the actual S3 objects here, I believe --recursive is needed.

```sh
$ awslocal s3 ls --recursive s3://order-receipts/
2026-08-22 08:55:37        136 receipts/6a9fb79d1845.json
```

Thank you 🙌